### PR TITLE
Workaround linking err in libcaercpp logAV etc functions

### DIFF
--- a/includecpp/libcaer.hpp
+++ b/includecpp/libcaer.hpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 #include <type_traits>
 
+/*
 namespace libcaer {
 namespace log {
 
@@ -67,5 +68,5 @@ void logVAFull(int logFileDescriptor1, int logFileDescriptor2, uint8_t systemLog
 
 }
 }
-
+*/
 #endif /* LIBCAER_HPP_ */


### PR DESCRIPTION
this is a temporary solution, which disables logging,
but enables the applications to compile

Fixes: #14 