### PR TITLE
Dynapse: set USB output chip ID for U0 to be 0, the same as input.

### DIFF
--- a/include/devices/dynapse.h
+++ b/include/devices/dynapse.h
@@ -486,15 +486,6 @@ extern "C" {
 /// Chip 3 ID.
 #define DYNAPSE_CONFIG_DYNAPSE_U3	12
 
-/// Chip 0 ID as output via USB.
-#define DYNAPSE_CONFIG_DYNAPSE_U0_OUT	1 // DYNAPSE_U0+1 -> 0+1 = 1.
-/// Chip 1 ID as output via USB.
-#define DYNAPSE_CONFIG_DYNAPSE_U1_OUT	8
-/// Chip 2 ID as output via USB.
-#define DYNAPSE_CONFIG_DYNAPSE_U2_OUT	4
-/// Chip 3 ID as output via USB.
-#define DYNAPSE_CONFIG_DYNAPSE_U3_OUT	12
-
 /// Number of cores per chip.
 #define DYNAPSE_CONFIG_NUMCORES				4
 /// Number of neurons in single chip.

--- a/include/events/spike.h
+++ b/include/events/spike.h
@@ -304,27 +304,6 @@ static inline void caerSpikeEventSetNeuronID(caerSpikeEvent event, uint32_t neur
 }
 
 /**
- * Get the Y (row) address for a spike event, in pixels.
- * The (0, 0) address is in the upper left corner.
- *
- * @param event a valid SpikeEvent pointer. Cannot be NULL.
- *
- * @return the event Y address in pixels.
- */
-static inline uint16_t caerSpikeEventGetY(caerSpikeEventConst event) {
-	uint8_t chipId = caerSpikeEventGetChipID(event);
-	uint8_t coreId = caerSpikeEventGetSourceCoreID(event);
-	uint32_t neuronId = caerSpikeEventGetNeuronID(event);
-
-	uint16_t columnId = (neuronId & 0x0F);
-	bool addColumn = (coreId & 0x01);
-	bool addColumnChip = (chipId & (0x01 << 2));
-	columnId = U16T(columnId + (addColumn) * 16 + (addColumnChip) * 32);
-
-	return (columnId);
-}
-
-/**
  * Get the X (column) address for a spike event, in pixels.
  * The (0, 0) address is in the upper left corner.
  *
@@ -337,14 +316,34 @@ static inline uint16_t caerSpikeEventGetX(caerSpikeEventConst event) {
 	uint8_t coreId = caerSpikeEventGetSourceCoreID(event);
 	uint32_t neuronId = caerSpikeEventGetNeuronID(event);
 
+	uint16_t columnId = (neuronId & 0x0F);
+	bool addColumn = (coreId & 0x02);
+	bool addColumnChip = ((chipId >> 2) & 0x02);
+	columnId = U16T(columnId + (addColumn * 16) + (addColumnChip * 32));
+
+	return (columnId);
+}
+
+/**
+ * Get the Y (row) address for a spike event, in pixels.
+ * The (0, 0) address is in the upper left corner.
+ *
+ * @param event a valid SpikeEvent pointer. Cannot be NULL.
+ *
+ * @return the event Y address in pixels.
+ */
+static inline uint16_t caerSpikeEventGetY(caerSpikeEventConst event) {
+	uint8_t chipId = caerSpikeEventGetChipID(event);
+	uint8_t coreId = caerSpikeEventGetSourceCoreID(event);
+	uint32_t neuronId = caerSpikeEventGetNeuronID(event);
+
 	uint16_t rowId = ((neuronId >> 4) & 0x0F);
-	bool addRow = (coreId & (0x01 << 1));
-	bool addRowChip = (chipId & (0x01 << 3));
-	rowId = U16T(rowId + (addRow) * 16 + (addRowChip) * 32);
+	bool addRow = (coreId & 0x01);
+	bool addRowChip = ((chipId >> 2) & 0x01);
+	rowId = U16T(rowId + (addRow * 16) + (addRowChip * 32));
 
 	return (rowId);
 }
-
 
 /**
  * Iterator over all Spike events in a packet.

--- a/src/dynapse.c
+++ b/src/dynapse.c
@@ -1079,6 +1079,15 @@ static void dynapseEventTranslator(void *vhd, uint8_t *buffer, size_t bytesSent)
 					}
 
 					uint8_t chipID = data & 0x0F;
+
+					// On output via SRAM routing->FPGA->USB, the chip ID for
+					// chip 0 is set to 1 so that it can work with the SRAM.
+					// But this is then inconsistent with the chip IDs as used
+					// everywhere else, so we reset this here for all users.
+					if (chipID == DYNAPSE_CONFIG_DYNAPSE_U0_OUT) {
+						chipID = DYNAPSE_CONFIG_DYNAPSE_U0;
+					}
+
 					uint32_t neuronID = (data >> 4) & 0x00FF;
 
 					caerSpikeEvent currentSpikeEvent = caerSpikeEventPacketGetEvent(state->currentSpikePacket,

--- a/src/dynapse.h
+++ b/src/dynapse.h
@@ -21,6 +21,15 @@
 #define DYNAPSE_SPIKE_DEFAULT_SIZE 4096
 #define DYNAPSE_SPECIAL_DEFAULT_SIZE 128
 
+// Chip 0 ID as output via USB.
+#define DYNAPSE_CONFIG_DYNAPSE_U0_OUT	1 // DYNAPSE_U0+1 -> 0+1 = 1.
+// Chip 1 ID as output via USB.
+#define DYNAPSE_CONFIG_DYNAPSE_U1_OUT	8
+// Chip 2 ID as output via USB.
+#define DYNAPSE_CONFIG_DYNAPSE_U2_OUT	4
+// Chip 3 ID as output via USB.
+#define DYNAPSE_CONFIG_DYNAPSE_U3_OUT	12
+
 struct dynapse_state {
 	// Per-device log-level
 	atomic_uint_fast8_t deviceLogLevel;


### PR DESCRIPTION
This way users don't have to remember all the time that USB input from chip 0 has a different ID: it doesn't anymore.
Also fix caerSpikeEventGetX/Y, the functions were inverting X/Y and other meanings.